### PR TITLE
Feature/hounslow ch59 redirects incorrectly applying

### DIFF
--- a/aws/lambda.yml
+++ b/aws/lambda.yml
@@ -74,10 +74,7 @@ Resources:
             let hasChanged = false;
 
             // Initialise the path mapping
-            const map = {
-              about: 'about-connect',
-              'get-involved': 'providers'
-            };
+            const map = {};
 
             // Rewrite URLs
             for (const [from, to] of Object.entries(map)) {


### PR DESCRIPTION
Removed redirects for about and get-involved from lambda function