### PR TITLE
Feature/hounslow ch213 homepage background illustration isn t aligned

### DIFF
--- a/src/views/Home/Home.scss
+++ b/src/views/Home/Home.scss
@@ -5,8 +5,8 @@
 .home {
   background-color: $light-turquoise;
   background-image: url('../../assets/images/backgrounds/park.svg');
-  background-position: center 320px;
-  background-size: 100% auto;
+  background-position: -32px 320px;
+  background-size: calc(100% + 35px) auto;
   background-repeat: no-repeat;
 
   @include for-phone-only {


### PR DESCRIPTION
The gap in the illustration was being caused by the fact that in the image file (https://staging.onehounslowconnect.london/static/media/park.0fe067da.svg) itself, there is a white space on the left.

I fixed this with CSS by offsetting the left positioning of the image by -32 pixels. 