### PR TITLE
Corrected S3 bucket domain name

### DIFF
--- a/aws/core.yml
+++ b/aws/core.yml
@@ -175,6 +175,7 @@ Resources:
         DefaultRootObject: index.html
         Enabled: True
         IPV6Enabled: True
+        HttpVersion: http2
         Origins:
         - DomainName:
             Fn::GetAtt:
@@ -190,6 +191,7 @@ Resources:
           AcmCertificateArn:
             Ref: CertificateArn
           SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2019
 
   WwwDistribution:
     Type: AWS::CloudFront::Distribution
@@ -211,9 +213,10 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
         Enabled: True
         IPV6Enabled: True
+        HttpVersion: http2
         Origins:
         - DomainName:
-            Fn::Sub: www.${Cname}.s3-website-${AWS::Region}.amazonaws.com
+            Fn::Sub: www.${Cname}.s3-website.${AWS::Region}.amazonaws.com
           Id:
             Fn::Join:
             - "-"
@@ -225,3 +228,4 @@ Resources:
           AcmCertificateArn:
             Ref: WwwCertificateArn
           SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2019


### PR DESCRIPTION
### Summary
Bugfix to allow www domains to redirect correctly to root domains
S3 domain name was incorrectly formed on the www domain within the cloudfront distribution

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
NA

### Notes
NA
